### PR TITLE
Fix workflow patterns

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.CICD_CODE_FILE_PATTERNS }}
 
   set-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.CODEQL_CODE_FILE_PATTERNS }}
 
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.LINTER_CODE_FILE_PATTERNS }}
 
   csharp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set workflow patterns separate for each workflow, this is to force a workflow updated by renovate to actually run to make sure it succeeds.