### PR TITLE
Refactor FakerBuilder class to include a ConfigureRules

### DIFF
--- a/DrifterApps.Seeds.sln.DotSettings
+++ b/DrifterApps.Seeds.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=fakerizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mediat/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=respawner/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Testing/FakerBuilder.cs
+++ b/src/Testing/FakerBuilder.cs
@@ -7,23 +7,55 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DrifterApps.Seeds.Testing;
 
+/// <summary>
+///     Abstract base class for building instances of <typeparamref name="T" /> using Faker.
+/// </summary>
+/// <typeparam name="T">The type of class to generate instances for.</typeparam>
 public abstract class FakerBuilder<T> where T : class
 {
-    /// <inheritdoc cref="Faker{T}" />
-    protected abstract Faker<T> FakerRules { get; }
+    /// <summary>
+    ///     Configures the rules for generating instances of <typeparamref name="T" />.
+    /// </summary>
+    /// <param name="fakerBuilder">The Faker builder to configure.</param>
+    /// <returns>The configured Faker builder.</returns>
+    protected abstract Faker<T> ConfigureRules(Faker<T> fakerBuilder);
 
-    public virtual T Build()
+    /// <summary>
+    ///     Builds an instance of <typeparamref name="T" /> using the configured rules.
+    /// </summary>
+    /// <returns>An instance of <typeparamref name="T" />.</returns>
+    public T Build()
     {
-        FakerRules.AssertConfigurationIsValid();
-        return FakerRules.Generate();
+        var builder = ConfigureRules(new Faker<T>());
+        builder.AssertConfigurationIsValid();
+        return builder.Generate();
     }
 
-    public virtual IReadOnlyCollection<T> BuildCollection(int? count = null)
+    /// <summary>
+    ///     Build a collection of entities.
+    /// </summary>
+    /// <param name="count">
+    ///     Optional number of entities to generate. If not provided, a random count will be used.
+    /// </param>
+    /// <returns>
+    ///     A read-only collection of entities of type <typeparamref name="T" />.
+    /// </returns>
+    public IReadOnlyCollection<T> BuildCollection(int? count = null)
     {
-        FakerRules.AssertConfigurationIsValid();
-        return FakerRules.Generate(count ?? Globals.RandomCollectionCount());
+        var builder = ConfigureRules(new Faker<T>());
+        builder.AssertConfigurationIsValid();
+        return builder.Generate(count ?? Globals.RandomCollectionCount());
     }
 
+    /// <summary>
+    ///     Asynchronously saves an instance of <typeparamref name="T" /> in the database.
+    /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <param name="databaseDriver">The database driver to use for saving the instance.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous save operation. The task result contains the saved instance of
+    ///     <typeparamref name="T" />.
+    /// </returns>
     public Task<T> SavedInDbAsync<TDbContext>(DatabaseDriver<TDbContext> databaseDriver) where TDbContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(databaseDriver);
@@ -43,6 +75,16 @@ public abstract class FakerBuilder<T> where T : class
         }
     }
 
+    /// <summary>
+    ///     Asynchronously saves a collection of instances of <typeparamref name="T" /> in the database.
+    /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <param name="databaseDriver">The database driver to use for saving the instances.</param>
+    /// <param name="count">Optional number of entities to generate. If not provided, a random count will be used.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous save operation. The task result contains a read-only collection of
+    ///     saved instances of <typeparamref name="T" />.
+    /// </returns>
     public Task<IReadOnlyCollection<T>> CollectionSavedInDbAsync<TDbContext>(DatabaseDriver<TDbContext> databaseDriver,
         int? count = null) where TDbContext : DbContext
     {

--- a/src/Testing/Globals.cs
+++ b/src/Testing/Globals.cs
@@ -1,18 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
 using Bogus;
 
 namespace DrifterApps.Seeds.Testing;
 
+/// <summary>
+///     Provides global settings and utilities for testing.
+/// </summary>
+[SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline")]
 public static class Globals
 {
-#pragma warning disable CA1810
-    static Globals()
-#pragma warning restore CA1810
-    {
-        Faker.DefaultStrictMode = true;
-    }
+    static Globals() => Faker.DefaultStrictMode = true;
 
+    /// <summary>
+    ///     Gets a new instance of the Faker class.
+    /// </summary>
     public static Faker Fakerizer => new();
 
+    /// <summary>
+    ///     Generates a random integer between 1 and 10.
+    /// </summary>
+    /// <returns>A random integer between 1 and 10.</returns>
     public static int RandomCollectionCount()
     {
         var faker = new Faker();

--- a/tests/Testing.Tests/Builders/ApiResourceBuilder.cs
+++ b/tests/Testing.Tests/Builders/ApiResourceBuilder.cs
@@ -3,21 +3,18 @@ using DrifterApps.Seeds.Testing.Infrastructure;
 
 namespace DrifterApps.Seeds.Testing.Tests.Builders;
 
-public class ApiResourceBuilder : FakerBuilder<ApiResource>
+internal class ApiResourceBuilder : FakerBuilder<ApiResource>
 {
     private string? _endpointTemplate;
     private HttpMethod? _httpMethod;
 
-    public ApiResourceBuilder() =>
-        FakerRules = new Faker<ApiResource>()
-            .CustomInstantiator(f =>
-                ApiResource.DefineApi(
-                    _endpointTemplate ?? f.Internet.UrlRootedPath(),
-                    _httpMethod ?? f.PickRandom(new List<HttpMethod>
-                        {HttpMethod.Get, HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch, HttpMethod.Delete})
-                ));
-
-    protected override Faker<ApiResource> FakerRules { get; }
+    protected override Faker<ApiResource> ConfigureRules(Faker<ApiResource> fakerBuilder) =>
+        fakerBuilder.CustomInstantiator(f =>
+            ApiResource.DefineApi(
+                _endpointTemplate ?? f.Internet.UrlRootedPath(),
+                _httpMethod ?? f.PickRandom(new List<HttpMethod>
+                    {HttpMethod.Get, HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch, HttpMethod.Delete})
+            ));
 
     public ApiResourceBuilder WithHttpMethod(HttpMethod httpMethod)
     {


### PR DESCRIPTION
- Updated the FakerBuilder class to include a ConfigureRules method for configuring the rules of generating instances of T.
- Added a SavedInDbAsync method to the FakerBuilder class for asynchronously saving an instance of T in the database.
- Added a CollectionSavedInDbAsync method to the FakerBuilder class for asynchronously saving a collection of instances of T in the database.
- Updated the Globals class to provide global settings and utilities for testing.
- Updated the ApiResourceBuilder class to use the ConfigureRules method for configuring the rules of generating instances of ApiResource.